### PR TITLE
Add html5 "autocomplete" property to input tags

### DIFF
--- a/project/reference/game03-action/start.html
+++ b/project/reference/game03-action/start.html
@@ -21,11 +21,11 @@
   
   <section>
 
-    <input type="radio" id="target1"/><label for="target1"></label>
-    <input type="radio" id="target2"/><label for="target2"></label>
-    <input type="radio" id="target3"/><label for="target3"></label>
-    <input type="radio" id="target4"/><label for="target4"></label>
-    <input type="radio" id="target5"/><label for="target5"></label>
+    <input type="radio" id="target1" autocomplete="off"/><label for="target1"></label>
+    <input type="radio" id="target2" autocomplete="off"/><label for="target2"></label>
+    <input type="radio" id="target3" autocomplete="off"/><label for="target3"></label>
+    <input type="radio" id="target4" autocomplete="off"/><label for="target4"></label>
+    <input type="radio" id="target5" autocomplete="off"/><label for="target5"></label>
 
   </section>
 


### PR DESCRIPTION
This commit fixes a bug in the game whereby radio buttons are not unchecked when refreshing the page in a browser, making the game impossible to play again without closing and reloading the page.

This bug can be reproduced, at the very least, on Firefox 47.0.1, 32 bit.

Adding the autocomplete="off" property to the input tags prevents the browser from automatically completing the radio buttons to their previous values and corrects the bug.
