### PR TITLE
slides.html: html links patch

### DIFF
--- a/slides.html
+++ b/slides.html
@@ -33,7 +33,7 @@
 
         <h2>Download<br> & Install</h2>
         <ol class="downloads">
-          <li>Learner files (zip file): <a href="https://github.com/ladieslearningcode/interactive-stories-and-game-making/master.zip">[LINK]</a>
+          <li>Learner files (zip file): <a href="https://github.com/ladieslearningcode/llc-interactive-stories-and-game-making/archive/master.zip">[LINK]</a>
             <ul>
               <li>unzip the learner file (<em>extract all</em> if you’re on a PC)</li>
               <li>open <em>slides.html</em> in the browser to view the slides</li>

--- a/slides.html
+++ b/slides.html
@@ -515,7 +515,7 @@
         * the `<title></title>` element is the only required element
           * defines the title of the web page/document
           * displayed in the browser tab, bookmarks and search engine results
-        * CSS, JavaScript & [metadata](searchenginewatch.com/sew/how-to/2067564/how-to-use-html-meta-tags) can also be included here
+        * CSS, JavaScript & [metadata](https://www.searchenginewatch.com/sew/how-to/2067564/how-to-use-html-meta-tags) can also be included here
         * page content *never* goes here
 
         <pre><code>&lt;!DOCTYPE html&gt;


### PR DESCRIPTION
This patch corrects broken links in the slide deck.
See commit messages for details.
