### PR TITLE
modified HTML files to URL encode the straight pipe '|' character

### DIFF
--- a/project/reference/exercise-answers/exercise-04.html
+++ b/project/reference/exercise-answers/exercise-04.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>Create Your Own Adventure</title>
     <!-- Link to Google Fonts -->
-    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400|Open+Sans:400,300' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400%7COpen+Sans:400,300' rel='stylesheet' type='text/css'>
     <!-- Link to your CSS file. Your file name should be 'styles.css' -->
     <link rel="stylesheet" href="exercise-04.css"> 
   </head>

--- a/project/reference/game02-textadventure/chair.html
+++ b/project/reference/game02-textadventure/chair.html
@@ -6,7 +6,7 @@
     <title>A LLC Mystery: Where Are All the Women in Tech?</title>
 
     <!-- LOAD IN EXTERNAL CSS STYLESHEETS IF YOU LIKE -->
-    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400|Open+Sans:400,300' rel='stylesheet'>
+    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400%7COpen+Sans:400,300' rel='stylesheet'>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css"/>
 
     <!-- REMEMBER TO INCLUDE YOUR OWN CSS STYLESHEET -->

--- a/project/reference/game02-textadventure/closet.html
+++ b/project/reference/game02-textadventure/closet.html
@@ -6,7 +6,7 @@
     <title>A LLC Mystery: Where Are All the Women in Tech?</title>
 
     <!-- LOAD IN EXTERNAL CSS STYLESHEETS IF YOU LIKE -->
-    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400|Open+Sans:400,300' rel='stylesheet'>
+    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400%7COpen+Sans:400,300' rel='stylesheet'>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css"/>
 
     <!-- REMEMBER TO INCLUDE YOUR OWN CSS STYLESHEET -->

--- a/project/reference/game02-textadventure/documentary.html
+++ b/project/reference/game02-textadventure/documentary.html
@@ -6,7 +6,7 @@
     <title>A LLC Mystery: Where Are All the Women in Tech?</title>
 
     <!-- LOAD IN EXTERNAL CSS STYLESHEETS IF YOU LIKE -->
-    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400|Open+Sans:400,300' rel='stylesheet'>
+    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400%7COpen+Sans:400,300' rel='stylesheet'>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css"/>
 
     <!-- REMEMBER TO INCLUDE YOUR OWN CSS STYLESHEET -->

--- a/project/reference/game02-textadventure/door-01-unlocked.html
+++ b/project/reference/game02-textadventure/door-01-unlocked.html
@@ -6,7 +6,7 @@
     <title>A LLC Mystery: Where Are All the Women in Tech?</title>
 
     <!-- LOAD IN EXTERNAL CSS STYLESHEETS IF YOU LIKE -->
-    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400|Open+Sans:400,300' rel='stylesheet'>
+    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400%7COpen+Sans:400,300' rel='stylesheet'>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css"/>
 
     <!-- REMEMBER TO INCLUDE YOUR OWN CSS STYLESHEET -->

--- a/project/reference/game02-textadventure/door-01.html
+++ b/project/reference/game02-textadventure/door-01.html
@@ -6,7 +6,7 @@
     <title>A LLC Mystery: Where Are All the Women in Tech?</title>
 
     <!-- LOAD IN EXTERNAL CSS STYLESHEETS IF YOU LIKE -->
-    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400|Open+Sans:400,300' rel='stylesheet'>
+    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400%7COpen+Sans:400,300' rel='stylesheet'>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css"/>
 
     <!-- REMEMBER TO INCLUDE YOUR OWN CSS STYLESHEET -->

--- a/project/reference/game02-textadventure/door-02.html
+++ b/project/reference/game02-textadventure/door-02.html
@@ -6,7 +6,7 @@
     <title>A LLC Mystery: Where Are All the Women in Tech?</title>
 
     <!-- LOAD IN EXTERNAL CSS STYLESHEETS IF YOU LIKE -->
-    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400|Open+Sans:400,300' rel='stylesheet'>
+    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400%7COpen+Sans:400,300' rel='stylesheet'>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css"/>
 
     <!-- REMEMBER TO INCLUDE YOUR OWN CSS STYLESHEET -->

--- a/project/reference/game02-textadventure/door-03.html
+++ b/project/reference/game02-textadventure/door-03.html
@@ -6,7 +6,7 @@
     <title>A LLC Mystery: Where Are All the Women in Tech?</title>
 
     <!-- LOAD IN EXTERNAL CSS STYLESHEETS IF YOU LIKE -->
-    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400|Open+Sans:400,300' rel='stylesheet'>
+    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400%7COpen+Sans:400,300' rel='stylesheet'>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css"/>
 
     <!-- REMEMBER TO INCLUDE YOUR OWN CSS STYLESHEET -->

--- a/project/reference/game02-textadventure/lobby-unlocked.html
+++ b/project/reference/game02-textadventure/lobby-unlocked.html
@@ -6,7 +6,7 @@
     <title>A LLC Mystery: Where Are All the Women in Tech?</title>
 
     <!-- LOAD IN EXTERNAL CSS STYLESHEETS IF YOU LIKE -->
-    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400|Open+Sans:400,300' rel='stylesheet'>
+    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400%7COpen+Sans:400,300' rel='stylesheet'>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css"/>
 
     <!-- REMEMBER TO INCLUDE YOUR OWN CSS STYLESHEET -->

--- a/project/reference/game02-textadventure/lobby.html
+++ b/project/reference/game02-textadventure/lobby.html
@@ -6,7 +6,7 @@
     <title>A LLC Mystery: Where Are All the Women in Tech?</title>
 
     <!-- LOAD IN EXTERNAL CSS STYLESHEETS IF YOU LIKE -->
-    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400|Open+Sans:400,300' rel='stylesheet'>
+    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400%7COpen+Sans:400,300' rel='stylesheet'>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css"/>
 
     <!-- REMEMBER TO INCLUDE YOUR OWN CSS STYLESHEET -->

--- a/project/reference/game02-textadventure/start.html
+++ b/project/reference/game02-textadventure/start.html
@@ -6,7 +6,7 @@
     <title>A LLC Mystery: Where Are All the Women in Tech?</title>
 
     <!-- LOAD IN EXTERNAL CSS STYLESHEETS IF YOU LIKE (E.G. Google Fonts, FontAwesome, etc) -->
-    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400|Open+Sans:400,300' rel='stylesheet'>
+    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400%7COpen+Sans:400,300' rel='stylesheet'>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css"/>
 
     <!-- REMEMBER TO INCLUDE YOUR OWN CSS STYLESHEET -->

--- a/project/reference/game02-textadventure/workshop.html
+++ b/project/reference/game02-textadventure/workshop.html
@@ -6,7 +6,7 @@
     <title>A LLC Mystery: Where Are All the Women in Tech?</title>
 
     <!-- LOAD IN EXTERNAL CSS STYLESHEETS IF YOU LIKE -->
-    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400|Open+Sans:400,300' rel='stylesheet'>
+    <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400%7COpen+Sans:400,300' rel='stylesheet'>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css"/>
 
     <!-- REMEMBER TO INCLUDE YOUR OWN CSS STYLESHEET -->

--- a/project/reference/game03-action/start.html
+++ b/project/reference/game03-action/start.html
@@ -6,7 +6,7 @@
   <title>LLC Carnival Game</title>
 
   <!-- LOAD IN EXTERNAL CSS STYLESHEETS IF YOU LIKE (E.G. Google Fonts, FontAwesome, etc) -->
-  <link href='https://fonts.googleapis.com/css?family=Quicksand:400,700|Ewert' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Quicksand:400,700%7CEwert' rel='stylesheet' type='text/css'>
 
   <!-- REMEMBER TO INCLUDE YOUR OWN CSS STYLESHEET -->
   <link rel="stylesheet" href="styles-advanced.css">

--- a/slides.html
+++ b/slides.html
@@ -1091,7 +1091,7 @@ selector { /* select the heading */
           <head>
             <meta charset="UTF-8">
             <title>Create Your Own Adventure</title>
-            <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400|Open+Sans:400,300' rel='stylesheet' type='text/css'>
+            <link href='https://fonts.googleapis.com/css?family=Passion+One:700,400%7COpen+Sans:400,300' rel='stylesheet' type='text/css'>
             <link rel="stylesheet" href="styles.css">
           </head>
           ```


### PR DESCRIPTION
modified slides and game HTML files to URL encode the straight pipe '|' character from Google fonts to '%7C' in order to comply with URL formatting standards (otherwise causes a validation error)
