### PR TITLE
remove "google fonts" from top of slides.html

### DIFF
--- a/slides.html
+++ b/slides.html
@@ -1,4 +1,3 @@
-google fonts
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
This change removes the invalid line "google fonts" from the top of the file, which was introduced with commit 5355159cb73f5d5a55419e8a29a949b9e3103a25.

That causes the line "google fonts" to appear on every slide and fails HTML validation.
